### PR TITLE
bug fix: git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: check-gitignore
         name: check for changes in the gitignore file
         description: prevents modifications to gitignore
-        entry: git-hooks/pre-commit/check-gitignore.sh
+        entry: ./git-hooks/pre-commit/check-gitignore.sh
         language: script
         stages: [pre-commit, pre-push, manual]
         minimum_pre_commit_version: 3.2.0
@@ -25,7 +25,7 @@ repos:
     -   id: check-staged-files
         name: Check the files staged for a commit.
         description: Prevent/Unstage unneccessary or important files from being committed
-        entry: git-hooks/pre-commit/check-staged-files.sh
+        entry: ./git-hooks/pre-commit/check-staged-files.sh
         language: script
         stages: [pre-commit, pre-push, manual]
         minimum_pre_commit_version: 3.2.0

--- a/git-hooks/pre-commit/check-gitignore.sh
+++ b/git-hooks/pre-commit/check-gitignore.sh
@@ -1,12 +1,14 @@
 #!sh
-# Check if .gitignore is modified and staged
-export GIT_CONFIG_KEY_0="user.name"
+# Hotfix from Issue #30 on GitHub
 export GIT_CONFIG_VALUE_0=""
-export GIT_CONFIG_KEY_1="user.email"
 export GIT_CONFIG_VALUE_1=""
 
+# Check if .gitignore is modified and staged
+
 if git diff --merge-base main --name-only --diff-filter=MD | grep -i '.gitignore'; then
+  set -x
   echo 'Backend/.gitignore modifications or deletions are not allowed! Fixing...'
+  set +x
   git checkout origin/main Backend/.gitignore
   exit 0
 fi

--- a/git-hooks/pre-commit/check-staged-files.sh
+++ b/git-hooks/pre-commit/check-staged-files.sh
@@ -1,12 +1,11 @@
 #!sh
-#!/bin/sh
 # Check if .gitignore is modified and staged
 export GIT_CONFIG_KEY_0="user.name"
 export GIT_CONFIG_VALUE_0=""
 export GIT_CONFIG_KEY_1="user.email"
 export GIT_CONFIG_VALUE_1=""
 
-output=$(git diff --name-only --cached --diff-filter=AM | grep -P '^\.env(?!\.example$).*')
+output=$(git diff --name-only HEAD | grep -P '^\.env(?!\.example$).*')
 
 if [ -n "$output" ]; then
   echo "Do not include files with credentials. Violating file: $output"

--- a/git-hooks/pre-commit/check-staged-files.sh
+++ b/git-hooks/pre-commit/check-staged-files.sh
@@ -1,14 +1,15 @@
 #!sh
-# Check if .gitignore is modified and staged
-export GIT_CONFIG_KEY_0="user.name"
+# Hotfix from Issue #30 on GitHub
 export GIT_CONFIG_VALUE_0=""
-export GIT_CONFIG_KEY_1="user.email"
 export GIT_CONFIG_VALUE_1=""
 
+# Check if .gitignore is modified and staged
 output=$(git diff --name-only HEAD | grep -P '^\.env(?!\.example$).*')
 
 if [ -n "$output" ]; then
+  set -x # Enables output of commands again
   echo "Do not include files with credentials. Violating file: $output"
+  set +x
   exit 1
 fi
 


### PR DESCRIPTION
## Prerequisite Ideas
OS: Windows 10
This bug was created under the environment where the Windows System PATH variable for Git/bin (which invokes `sh` later in the bash script)

`C:\Program Files\Git\bin` 

It's a bug with the `sh` script being unexecutable (declared at the shebang at the start of the file) (think its specifically for Windows but using the Git installed shell and `wsl -d Ubuntu` is fine, but is needed to be declared in the environment variables at a higher priority, which was tested on @warkionw 's Windows 10 computer.)

## Known Bugs
### 1. Pre-Commit Framework: GitHub Desktop Environment Variable Inheritance
#### Problem Scenario:
When using **GitHub Desktop** to commit the files, the following error is thrown in the window when a pre-commit hook is invoked:

```cmd
Check the files staged for a commit......................................Failed
- hook id: check-staged-files
- exit code: 1

error: missing config value GIT_CONFIG_VALUE_0
fatal: unable to parse command-line config
```
Which is a fatal error because the entire git environment is unable to initialise itself for any other function that isn't configuration. Referencing the git-config command, the system contains the [GIT_CONFIG_COUNT](https://git-scm.com/docs/git-config#ENVIRONMENT) environment variable (in my case, GIT_CONFIG_COUNT=2) but fails to initialise the GIT_CONFIG_VALUE_0 & _1.

> **via git-config ENVIRONMENT**
> If GIT_CONFIG_COUNT is set to a positive number, all environment pairs GIT_CONFIG_KEY_<n> and GIT_CONFIG_VALUE_<n>
> up to that number will be added to the process’s runtime configuration. The config pairs are zero-indexed. Any missing key or
> value is treated as an error. An empty GIT_CONFIG_COUNT is treated the same as GIT_CONFIG_COUNT=0, namely no pairs
> are processed. These environment variables will override values in configuration files, but will be overridden by any explicit
> options passed via git -c.

#### Working Theory
The working theory behind the bug is that during the initialisation of the shell environment for execution of the bash scripts, the key-pair values `GIT_CONFIG_KEY_0` and `GIT_CONFIG_KEY_1`, which declares the user's name and email, isn't initialised or given a value in the inherited config file during the virtualisation for **GitHub Desktop**. This does not occur in both git bash cli and cmd manually with `git commit`. The following is the output printing out the env variables:

```**GitHub Desktop Message Window**
check for changes in the gitignore file..................................Failed
- hook id: check-gitignore
- exit code: 1

GIT_CONFIG_VALUE_1=desktop //declared before the key? Not sure if this works
GIT_CONFIG_COUNT=2
GIT_CONFIG_KEY_1=credential.helper
GIT_CONFIG_KEY_0=credential.helper
```

#### Hotfix:
The sample below contains the hotfix in the hook bash files (namely tested on Windows GitHub Desktop). 

```bash
#!sh //With Git/bin already in PATH
# Check if .gitignore is modified and staged
export GIT_CONFIG_VALUE_0=""
export GIT_CONFIG_VALUE_1=""

output=$(git diff --name-only HEAD | grep -P '^\.env(?!\.example$).*')

if [ -n "$output" ]; then
  echo "Do not include files with credentials. Violating file: $output"
  exit 1
fi

exit 0
```

oogabooga fix but it works 