### PR TITLE
aws user task def

### DIFF
--- a/.github/workflows/aws-user.yml
+++ b/.github/workflows/aws-user.yml
@@ -32,12 +32,13 @@ on:
     paths:
       - 'Backend/User/src/**' # Run when there is a push to the path User/src
       - 'Backend/User/Dockerfile'
+      - 'Backend/User/pom.xml'
   workflow_dispatch:
 
 env:
   AWS_REGION: ap-southeast-1                  # set this to your preferred AWS region, e.g. us-west-1
   ECR_REPOSITORY: cs203/user          # set this to your Amazon ECR repository name
-  ECS_SERVICE: user-task                 # set this to your Amazon ECS service name
+  ECS_SERVICE: user-launch                 # set this to your Amazon ECS service name
   ECS_CLUSTER: cs203-user          # set this to your Amazon ECS cluster name
   ECS_TASK_DEFINITION: user:2
   CONTAINER_NAME: user           # set this to the name of the container in the
@@ -80,15 +81,22 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-    - name: Run Middleware Task from ECS
-      id: run-task
-      working-directory: Backend/Middleware
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        IMAGE_TAG: ${{ github.sha }}
+    - name: Download task definition
       run: |
-        aws ecs run-task \
-        --cluster ${{ env.ECS_CLUSTER }} \
-        --task-definition ${{env.ECS_TASK_DEFINITION}} \
-        --launch-type FARGATE \
-        --network-configuration "awsvpcConfiguration={subnets=[${{ secrets.AWS_VPC_SUBNETS }}],securityGroups=[${{ secrets.AWS_SG_ID }}],assignPublicIp='ENABLED'}"
+        aws ecs describe-task-definition --task-definition user --query taskDefinition > task-definition.json
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: ${{ env.CONTAINER_NAME }}
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true


### PR DESCRIPTION
fixes include:
- defining a application load balancer for DNS resolution to the ECS Cluster instead of an individual instance
- download the task definition for github actions 
- execute within the service cluster (because of the alb) 